### PR TITLE
Update tags for Julia 1.0; fix #3

### DIFF
--- a/ctags
+++ b/ctags
@@ -1,4 +1,5 @@
 --langdef=julia
 --langmap=julia:.jl
---regex-julia=/^[ \t]*(function|macro|abstract type|primitive type|struct|mutable struct|typealias|module)[ \t]+([^ \t({[]+).*$/\2/f,function/
---regex-julia=/^[ \t]*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\)|\((\$)\))[ \t]*(\{.*\})?[ \t]*\([^#]*\)[ \t]*=([^=].*$|$)/\2\3\4/f,function/
+--regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(function|macro|abstract type|primitive type|struct|mutable struct|module)[ \t]+([^ \t({[]+).*$/\4/f,function/
+--regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\))[ \t]*[ \t]*\([^#]*\)([ \t]+where[ \t]+\{.*\})?[ \t]*=([^=].*$|$)/\4\5/f,function/
+--regex-julia=/^(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(const[ \t]+)?(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*([^@#$ \t({[]+)[ \t]*=([^=].*$|$)/\6/v,variable/

--- a/ctags
+++ b/ctags
@@ -1,5 +1,5 @@
 --langdef=julia
 --langmap=julia:.jl
 --regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(function|macro|abstract type|primitive type|struct|mutable struct|module)[ \t]+([^ \t({[]+).*$/\4/f,function/
---regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\))[ \t]*[ \t]*\([^#]*\)([ \t]+where[ \t]+\{.*\})?[ \t]*=([^=].*$|$)/\4\5/f,function/
---regex-julia=/^(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(const[ \t]+)?(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*([^@#$ \t({[]+)[ \t]*=([^=].*$|$)/\6/v,variable/
+--regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\))[ \t]*[ \t]*\([^#]*\)([ \t]+where[ \t]+\{.*\})?[ \t]*=([^=].*)?$/\4\5/f,function/
+--regex-julia=/^(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(const[ \t]+)?(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*([^@#$ \t({[]+)[ \t]*=([^=].*)?$/\6/v,variable/


### PR DESCRIPTION
Add support for arbitrarily many macros before functions.
Add variables defined on the start of a line (also has macro support).
Add support for type parameterized inline function, that is
`f(x::T) where {T} = [...]`.

Remove dollar symbols; I don't know their meaning as I haven't used
Julia before 1.0.
Remove `typealias` keyword; does not exist in Julia 1.0.

Problems:
   - Still could use cleanup to not assign the 'function' kind to
     `struct`s, for example.
   - If any matched identifier is between strings or comments, it will
     _not_ be ignored.
   - Lambda functions are added as variables.
   - Functions in the non-global scope are also added. May be desired.